### PR TITLE
Multivariate g support for centralmoment

### DIFF
--- a/src/koopman.jl
+++ b/src/koopman.jl
@@ -353,35 +353,40 @@ function expectation(g::Function, S::Function, u0, p, expalg::MonteCarlo, args..
 end
 
 """
-    centralmoment(n, g, args...; kwargs) -> [n by 1 Array]
+    centralmoment(n, g, args...; kwargs)
 
 Computes the n central moments of the function g using the Koopman expectation.
 The function is a wrapper over expectation, arguments can be piped through with
 args and kwargs.
 
-Return: n-length array of the 1 to n central moments
+Return: nout-length array containing the n-length array of the 1 to n central 
+moments for each dimension of (possibly) multivariate g 
 
 Note: The first central moment is, by definition, always 0
 
-TODO: - add support for vector-valued g functions, currently assumes scalar 
-      return values.
-      - add tests
+TODO: - add tests
 """
-function centralmoment(n::Int, g::Function, args...; kwargs...) 
-    if n < 2 return Float64[] end
+function centralmoment(n::Int, g::Function, args...; nout=1, kwargs...) 
+    if n < 2 return nothing end
 
-    # Compute the expectations of g, g^2, ..., g^n
-    sol = expectation(x -> [g(x)^i for i in 1:n], args...; nout = n, kwargs...)
-    exp_set = sol.u
-    mu_g = popfirst!(exp_set)
-
-    # Combine according to binomial expansion
-    const_term(n) = (-1)^(n-1) * (n-1) * mu_g^n
-    binom_term(n, k, mu, exp_gi) = binomial(n, k) * (-mu)^(n - k) * exp_gi
-    binom_sum = function (exp_vals)
-        m = length(exp_vals) + 1
-        sum([binom_term(m, k + 1, mu_g, v) for (k,v) in enumerate(exp_vals)]) + const_term(m)
+    # only want to evaluate g once
+    function g_raisedn(x)
+        y = g(x)
+        return ArrayPartition([y.^i for i in 1:n]...)
     end
 
-    return [zero(exp_set[1]), [binom_sum(exp_set[1:i]) for i in 1:length(exp_set)]...]
+    # Compute the expectations of g, g^2, ..., g^n
+    sol = expectation(g_raisedn, args...; nout = n*nout, kwargs...)
+    gn_expvals = sol.u
+
+    # Combine according to binomial expansion
+    binom_term(n, k, mu, exp_gi) = binomial(n, k) * (-mu)^(n - k) * exp_gi
+    binom_sum = function (i, n, gi_expvals)
+        mu = gi_expvals.x[1][i]
+        iterms = [binom_term(n, k, mu, gi_expvals.x[k][i]) for k in 1:n]
+        return sum(iterms) + (-1)^n * mu^n
+    end
+    gi_moments = [[0., [binom_sum(i, l, gn_expvals) for l in 2:n]...] for i in 1:nout]
+
+    return nout == 1 ? gi_moments[1] : gi_moments
 end


### PR DESCRIPTION
* handles the case when `g` is multivariate, using the `nout` keyword ard
* returns an nout-length array of the n-length array of central moments, so the output is organized primarily by the individual elements of multivariate `g`